### PR TITLE
 Use styles prop instead of svgStyles when constructing D3Node

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function bar({
 
   const d3n = new D3Node({
     selector: _selector,
-    svgStyles: _svgStyles + _style,
+    styles: _svgStyles + _style,
     container: _container
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3node-barchart",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "D3-Node example - BarChart",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
d3-node has deprecated the svgStyles prop: https://github.com/d3-node/d3-node/blob/v1.0.3/index.js#L35

This change stops the deprecation warnings you get when you create a chart.

Using the styles prop to pass svgStyles works fine.